### PR TITLE
Feature/mingw support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 test/build/
 test_package/build/
 *.pyc
+build
+sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 include("CMakeListsOriginal.txt")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,13 +1,11 @@
 from conans import ConanFile, CMake, tools
-import os
+import os, shutil
 
 
 class JsoncppConan(ConanFile):
-    """ requires C++11 to build and consume
-    """
     name        = "jsoncpp"
     version     = "1.8.4"
-    description = "A C++11 library for interacting with JSON."
+    description = "A C++ library for interacting with JSON."
     url         = "https://github.com/theirix/conan-jsoncpp"
     license     = "Public Domain or MIT (https://github.com/open-source-parsers/jsoncpp/blob/master/LICENSE)"
     homepage    = "https://github.com/open-source-parsers/jsoncpp"
@@ -18,7 +16,7 @@ class JsoncppConan(ConanFile):
     generators  = "cmake", "txt"
 
     # Workaround for long cmake binary path
-    short_paths = True
+    # short_paths = True
 
     options = {
         "shared"              : [True, False],
@@ -37,7 +35,7 @@ class JsoncppConan(ConanFile):
         tools.get("https://github.com/open-source-parsers/jsoncpp/archive/%s.tar.gz" % self.version)
         os.rename("jsoncpp-%s" % self.version, "sources")
         os.rename("sources/CMakeLists.txt", "sources/CMakeListsOriginal.txt")
-        os.rename("CMakeLists.txt", "sources/CMakeLists.txt")
+        shutil.copy("CMakeLists.txt", "sources/CMakeLists.txt")
 
     def build(self):
         cmake = CMake(self)
@@ -48,7 +46,7 @@ class JsoncppConan(ConanFile):
         cmake.definitions['BUILD_STATIC_LIBS'] = not self.options.shared
         cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.use_pic
 
-        cmake.configure(source_dir="sources", build_dir="./")
+        cmake.configure(source_folder="sources")
         cmake.build()
 
     def package(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,10 +1,13 @@
 from conans import ConanFile, CMake, tools
 import os
 
+
 class JsoncppConan(ConanFile):
+    """ requires C++11 to build and consume
+    """
     name        = "jsoncpp"
     version     = "1.8.4"
-    description = "A C++ library for interacting with JSON."
+    description = "A C++11 library for interacting with JSON."
     url         = "https://github.com/theirix/conan-jsoncpp"
     license     = "Public Domain or MIT (https://github.com/open-source-parsers/jsoncpp/blob/master/LICENSE)"
     homepage    = "https://github.com/open-source-parsers/jsoncpp"
@@ -57,11 +60,13 @@ class JsoncppConan(ConanFile):
             elif self.settings.os == "Windows":
                 self.copy(pattern="*.dll", dst="bin", src="bin", keep_path=False)
                 self.copy(pattern="*.lib", dst="lib", src="lib", keep_path=False)
+                self.copy(pattern="*.a", dst="lib", src="lib", keep_path=False)
             else:
                 self.copy(pattern="*.so*", dst="lib", keep_path=False)
         else:
             if self.settings.os == "Windows":
                 self.copy(pattern="*.lib", dst="lib", src="lib", keep_path=False)
+                self.copy(pattern="*.a", dst="lib", src="lib", keep_path=False)
             else:
                 self.copy(pattern="*.a", dst="lib", keep_path=False)
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,7 +1,9 @@
 project(test_package)
 cmake_minimum_required(VERSION 2.8.12)
 
-add_definitions(-std=c++11)
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+SET(CMAKE_CXX_EXTENSIONS OFF)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 


### PR DESCRIPTION
I am doing the PR to master branch, I haven't found release branches for 1.8.4 and 1.8.3, so maybe it has to be fired manually?

I have proposed the following changes:

- Adding .a libraries in ``package()`` for Windows Mingw support
- Disabled short_paths, tested in Windows with different VS and Mingw, everything seems good.
- With the change to ``cmake.configure(source_folder="sources")`` this allows to use the more standard cmake ``include(${CMAKE_BINAR_DIR}/conanbuildinfo.cmake)``, but also, which is very nice, it allows local development. I have tested to do:

```bash
$ conan source .
$ mkdir build & cd build
$ conan install ..
$ conan build ..
$ conan export-pkg .. user/testing
```

And it works! :) I think it is nice to have it, and I wanted to try a few things..., though it is not necessary, so feel free to discard it.

I have tested the recipe to cross-build to R-PI too, works great.
