### PR TITLE
Support jsoncpp 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ matrix:
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
       - <<: *osx
         osx_image: xcode7.3
         env: CONAN_APPLE_CLANG_VERSIONS=7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
      - CONAN_REFERENCE: "jsoncpp/1.8.4"
      - CONAN_USERNAME: "theirix"
      - CONAN_LOGIN_USERNAME: "theirix"
-     - CONAN_CHANNEL: "testing"
+     - CONAN_CHANNEL: "stable"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/theirix/conan-repo"
 
 linux: &linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-
 env:
    global:
-     - CONAN_REFERENCE: "jsoncpp/1.8.4"
      - CONAN_USERNAME: "theirix"
      - CONAN_LOGIN_USERNAME: "theirix"
-     - CONAN_CHANNEL: "stable"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/theirix/conan-repo"
 
 linux: &linux
@@ -40,6 +37,9 @@ matrix:
       - <<: *osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0
+      - <<: *osx
+        osx_image: xcode9.3
+        env: CONAN_APPLE_CLANG_VERSIONS=9.1
 
 install:
   - chmod +x .travis/install.sh
@@ -47,4 +47,4 @@ install:
 
 script:
   - chmod +x .travis/run.sh
-  - ./.travis/run.sh
+- ./.travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ matrix:
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
       - <<: *osx
         osx_image: xcode7.3
         env: CONAN_APPLE_CLANG_VERSIONS=7.3
@@ -43,4 +41,4 @@ install:
 
 script:
   - chmod +x .travis/run.sh
-- ./.travis/run.sh
+  - ./.travis/run.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,3 @@
-env:
-   global:
-     - CONAN_USERNAME: "theirix"
-     - CONAN_LOGIN_USERNAME: "theirix"
-     - CONAN_UPLOAD: "https://api.bintray.com/conan/theirix/conan-repo"
-
 linux: &linux
    os: linux
    sudo: required
@@ -28,6 +22,8 @@ matrix:
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=lasote/conanclang39
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
+      - <<: *linux
+        env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=lasote/conanclang50
       - <<: *osx
         osx_image: xcode7.3
         env: CONAN_APPLE_CLANG_VERSIONS=7.3

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -20,6 +20,6 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
 fi
 
 pip install conan --upgrade
-pip install conan_package_tools
+pip install conan_package_tools bincrafters_package_tools
 
 conan user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(cmake_wrapper)
 
-include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+message(STATUS "Conan CMake Wrapper")
+include(conanbuildinfo.cmake)
 conan_basic_setup()
 
-include("CMakeListsOriginal.txt")
+add_subdirectory("source_subfolder")

--- a/README.md
+++ b/README.md
@@ -12,34 +12,35 @@ The packages generated with this **conanfile** can be found in [bintray](https:/
 
     $ pip install conan_package_tools
     $ python build.py
-    
+
 ## Reuse the packages
 
 ### basic setup
 
-    $ conan install jsoncpp/1.8.4@theirix/stable
+    $ conan install jsoncpp/1.0.0@theirix/stable
 
 ### Prerequirements
 
     JsonCpp needs at least cmake 3.1 for building.
     If you do not have one, specify flag jsoncpp:use_cmake_installer=True
-    
+
 ### Project setup
 
 If you handle multiple dependencies in your project is better to add a *conanfile.txt*
-    
+
     [requires]
-    jsoncpp/1.8.4@theirix/stable
+    jsoncpp/1.0.0@theirix/stable
 
     [options]
     jsoncpp:shared=true # false
-    
+    jsoncpp:fPIC=true # false (Only for Linux)
+
     [generators]
     txt
     cmake
 
 Complete the installation of requirements for your project running:
 
-    conan install . 
+    conan install .
 
 Project setup installs the library (and all his dependencies) and generates the files *conanbuildinfo.txt* and *conanbuildinfo.cmake* with all the paths and variables that you need to link with your dependencies.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
     CONAN_REFERENCE: "jsoncpp/1.8.4"
     CONAN_USERNAME: "theirix"
     CONAN_LOGIN_USERNAME: "theirix"
-    CONAN_CHANNEL: "testing"
+    CONAN_CHANNEL: "stable"
     CONAN_UPLOAD: "https://api.bintray.com/conan/theirix/conan-repo"
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,28 +5,35 @@ environment:
     PYTHON_VERSION: "2.7.8"
     PYTHON_ARCH: "32"
 
-    CONAN_REFERENCE: "jsoncpp/1.8.4"
     CONAN_USERNAME: "theirix"
     CONAN_LOGIN_USERNAME: "theirix"
-    CONAN_CHANNEL: "stable"
     CONAN_UPLOAD: "https://api.bintray.com/conan/theirix/conan-repo"
 
     matrix:
-        - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix, 4.9@x86_64@sjlj@posix, 4.9@x86@sjlj@posix, 4.9@x86@dwarf2@posix, 6.3@x86_64@seh@posix, 7.1@x86_64@seh@posix'
-        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
-          CONAN_VISUAL_VERSIONS: 11
+        - MINGW_CONFIGURATIONS: '4.9@x86_64@seh@posix, 5@x86_64@seh@posix, 6@x86_64@seh@posix, 7@x86_64@seh@posix'
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Release
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
           CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Release
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+          CONAN_BUILD_TYPES: Debug
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
           CONAN_VISUAL_VERSIONS: 15
-
+          CONAN_BUILD_TYPES: Release
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+          CONAN_BUILD_TYPES: Debug
 
 install:
   - set PATH=%PATH%;%PYTHON%/Scripts/
   - pip.exe install conan --upgrade
-  - pip.exe install conan_package_tools
+  - pip.exe install conan_package_tools bincrafters_package_tools
   - conan user # It creates the conan data directory
 
 test_script:

--- a/build.py
+++ b/build.py
@@ -6,6 +6,6 @@ from bincrafters import build_template_default
 
 if __name__ == "__main__":
 
-    builder = build_template_default.get_builder()
+    builder = build_template_default.get_builder(pure_c=False)
 
 builder.run()

--- a/build.py
+++ b/build.py
@@ -1,16 +1,11 @@
-from conan.packager import ConanMultiPackager
-import copy
-import platform
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+from bincrafters import build_template_default
 
 if __name__ == "__main__":
-    builder = ConanMultiPackager()
-    builder.add_common_builds(shared_option_name="jsoncpp:shared", pure_c=False)
 
-    builds = []
-    for settings, options, env_vars, build_requires in builder.builds:
-        # skip mingw cross-builds
-        if not (platform.system() == "Windows" and settings["compiler"] == "gcc" and settings["arch"] == "x86"):
-            builds.append([settings, options, env_vars, build_requires])
-    builder.builds = builds
+    builder = build_template_default.get_builder()
 
-    builder.run()
+builder.run()

--- a/build.py
+++ b/build.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-
+import os
 from bincrafters import build_template_default
 
 if __name__ == "__main__":
-
+    os.environ["CONAN_USERNAME"] = os.getenv("CONAN_USERNAME", "theirix")
+    os.environ["CONAN_LOGIN_USERNAME"] = os.getenv("CONAN_LOGIN_USERNAME", "theirix")
+    os.environ["CONAN_UPLOAD"] = os.getenv("CONAN_UPLOAD", "https://api.bintray.com/conan/theirix/conan-repo")
     builder = build_template_default.get_builder(pure_c=False)
-
-builder.run()
+    builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,76 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from conans import ConanFile, CMake, tools
-import os, shutil
+import os
 
 
 class JsoncppConan(ConanFile):
     name        = "jsoncpp"
-    version     = "1.8.4"
+    version     = "1.0.0"
     description = "A C++ library for interacting with JSON."
     url         = "https://github.com/theirix/conan-jsoncpp"
     license     = "Public Domain or MIT (https://github.com/open-source-parsers/jsoncpp/blob/master/LICENSE)"
     homepage    = "https://github.com/open-source-parsers/jsoncpp"
+    author      = "theirix"
     settings    = "os", "compiler", "arch", "build_type"
-
     exports = ["LICENSE.md"]
     exports_sources = ["CMakeLists.txt"]
-    generators  = "cmake", "txt"
+    generators  = "cmake"
+    options = {"shared": [True, False], "fPIC": [True, False]}
+    default_options = ("shared=False", "fPIC=True")
+    source_subfolder = "source_subfolder"
+    build_subfolder = "build_subfolder"
 
-    # Workaround for long cmake binary path
-    # short_paths = True
-
-    options = {
-        "shared"              : [True, False],
-        "use_pic"             : [True, False]
-    }
-    default_options = (
-        "shared=False",
-        "use_pic=False"
-    )
-
-    def configure(self):
-        if self.options.shared:
-            self.options.use_pic = True
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.remove('fPIC')
 
     def source(self):
-        tools.get("https://github.com/open-source-parsers/jsoncpp/archive/%s.tar.gz" % self.version)
-        os.rename("jsoncpp-%s" % self.version, "sources")
-        os.rename("sources/CMakeLists.txt", "sources/CMakeListsOriginal.txt")
-        shutil.copy("CMakeLists.txt", "sources/CMakeLists.txt")
+        tools.get("{0}/archive/{1}.tar.gz".format(self.homepage, self.version))
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self.source_subfolder)
+
+    def configure_cmake(self):
+        cmake = CMake(self)
+        cmake.definitions['JSONCPP_WITH_CMAKE_PACKAGE'] = True
+        cmake.definitions['JSONCPP_WITH_TESTS'] = False
+        cmake.definitions['JSONCPP_WITH_PKGCONFIG_SUPPORT'] = False
+        cmake.definitions['JSONCPP_LIB_BUILD_SHARED'] = self.options.shared
+        cmake.configure(build_folder=self.build_subfolder)
+        return cmake
 
     def build(self):
         if self.settings.compiler == "Visual Studio" and self.settings.compiler.version == "11":
-            tools.replace_in_file(os.path.join("sources", "include", "json", "value.h"),
+            tools.replace_in_file(os.path.join(self.source_subfolder, "include", "json", "value.h"),
                                   "explicit operator bool()",
                                   "operator bool()")
-        cmake = CMake(self)
-
-        cmake.definitions['JSONCPP_WITH_CMAKE_PACKAGE'] = True
-        cmake.definitions['JSONCPP_WITH_TESTS'] = False
-        cmake.definitions['BUILD_SHARED_LIBS'] = self.options.shared
-        cmake.definitions['BUILD_STATIC_LIBS'] = not self.options.shared
-        cmake.definitions['CMAKE_POSITION_INDEPENDENT_CODE'] = self.options.use_pic
-
-        cmake.configure(source_folder="sources")
+        cmake = self.configure_cmake()
         cmake.build()
 
     def package(self):
-        self.copy("license*", src="sources", dst="licenses", ignore_case=True, keep_path=False)
-        self.copy("*.h", dst="include", src="sources/include")
-        if self.options.shared:
-            if self.settings.os == "Macos":
-                self.copy(pattern="*.dylib", dst="lib", keep_path=False)
-            elif self.settings.os == "Windows":
-                self.copy(pattern="*.dll", dst="bin", src="bin", keep_path=False)
-                self.copy(pattern="*.lib", dst="lib", src="lib", keep_path=False)
-                self.copy(pattern="*.a", dst="lib", src="lib", keep_path=False)
-            else:
-                self.copy(pattern="*.so*", dst="lib", keep_path=False)
-        else:
-            if self.settings.os == "Windows":
-                self.copy(pattern="*.lib", dst="lib", src="lib", keep_path=False)
-                self.copy(pattern="*.a", dst="lib", src="lib", keep_path=False)
-            else:
-                self.copy(pattern="*.a", dst="lib", keep_path=False)
+        self.copy("LICENSE", src=self.source_subfolder, dst="licenses")
+        cmake = self.configure_cmake()
+        cmake.install()
 
     def package_info(self):
-        self.cpp_info.libs = ['jsoncpp']
+        self.cpp_info.libs = tools.collect_libs(self)

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,9 +1,8 @@
 project(test_package)
 cmake_minimum_required(VERSION 2.8.12)
 
-SET(CMAKE_CXX_STANDARD 11)
-SET(CMAKE_CXX_STANDARD_REQUIRED ON)
-SET(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -14,11 +14,6 @@ class TestPackageConan(ConanFile):
         cmake.configure()
         cmake.build()
 
-    def imports(self):
-        self.copy("*.dll", dst="bin", src="bin")
-        self.copy("*.so", dst="bin", src="lib")        
-        self.copy("*.dylib*", dst="bin", src="lib")
-
     def test(self):
         with tools.environment_append(RunEnvironment(self).vars):
             bin_path = os.path.join("bin", "test_package")

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -1,11 +1,11 @@
+#include <cstdlib>
 #include <string>
 #include <iostream>
-#include <json/json.h>
 
-int
-main(int argc, char **argv)
-{
+#include "json/json.h"
+
+int main(int argc, char **argv) {
 	Json::Value value("Hello, World");
 	std::cout << value.asString() << std::endl;
-	return 0;
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hi @theirix !

This PR has the sadly support for a legacy project using jsonrpc-cpp.
It's working on both CI, including Appveyor and Travis.

I used Bincrafters package tools to wrap CPT. If want to revert to classical CPT only, please comment that I'll remove. 

Regards!

Closes #8 